### PR TITLE
Disable the items and skills UI

### DIFF
--- a/Swamp Sneak/Assets/UI/HUD/HUD.prefab
+++ b/Swamp Sneak/Assets/UI/HUD/HUD.prefab
@@ -148,7 +148,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1321642905991874
 GameObject:
   m_ObjectHideFlags: 1
@@ -212,7 +212,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1476693825664146
 GameObject:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
Since they are not implemented, and may not be implemented by the end of the sprint. I figured we may as well turn them off and hide them, so as to not cause confusion? I'm not sure, maybe we do want them?